### PR TITLE
Updating ActivePatterns to use Some(...) when returning non nothing results

### DIFF
--- a/ActivePatterns.jl
+++ b/ActivePatterns.jl
@@ -2,7 +2,7 @@ using MLStyle
 
 
 @active Re{r :: Regex}(x) begin
-    match(r, x)
+    let temp = match(r, x); ifelse(temp === nothing, temp, Some(temp)) end
 end
 
 
@@ -27,21 +27,21 @@ green = RGB(0, 150, 50)
 
 @active Red(x) begin
     @match (x.R, x.G, x.B) begin
-        (118:138, 0:10, 0:10) => :maroon
-        (129:149, 0:10, 0:10) => :dark_red
-        (210:230, 10:30, 50:70) => :crimson
-        (155:175, 32:52, 32:52) => :brown
-        (100:255, 0:110, 0:110) => :unknown
+	(118:138, 0:10, 0:10) => Some(:maroon)
+	(129:149, 0:10, 0:10) => Some(:dark_red)
+	(210:230, 10:30, 50:70) => Some(:crimson)
+	(155:175, 32:52, 32:52) => Some(:brown)
+	(100:255, 0:110, 0:110) => Some(:unknown)
         _ => nothing
     end
 end
 
 @active Green(x) begin
     @match (x.R, x.G, x.B) begin
-        (0:10, 90:110, 0:10) => :dark_green
-        (0:10, 118:138, 0:10) => :green
-        (24:44, 129:149, 24:44) => :forest_green
-        (0:100, 100:255, 0:100) => :unknown
+	(0:10, 90:110, 0:10) => Some(:dark_green)
+	(0:10, 118:138, 0:10) => Some(:green)
+	(24:44, 129:149, 24:44) => Some(:forest_green)
+	(0:100, 100:255, 0:100) => Some(:unknown)
         _ => nothing
     end
 end
@@ -56,7 +56,4 @@ end
     Green(x) => (println(x); true)
     _ => false
 end
-
-
-
 


### PR DESCRIPTION
The previous version was not working as inside @active macro only the actual value was returned, but for non nothing values is necessary to enclose value inside Some(...). Without this change it doesn't work.